### PR TITLE
feat: 상품 둥록, 조회 api 구현

### DIFF
--- a/src/main/java/com/capstone/shop/entity/Image.java
+++ b/src/main/java/com/capstone/shop/entity/Image.java
@@ -1,0 +1,34 @@
+package com.capstone.shop.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class Image {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    private Merchandise merchandise;
+
+    @Enumerated(EnumType.STRING)
+    private PictureType pictureType;
+
+    @Column
+    private String pictureUrl;
+}

--- a/src/main/java/com/capstone/shop/entity/Merchandise.java
+++ b/src/main/java/com/capstone/shop/entity/Merchandise.java
@@ -1,0 +1,42 @@
+package com.capstone.shop.entity;
+
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class Merchandise {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column
+    private String name;
+
+    @Column
+    private int price;
+
+    @Column
+    private String location;
+
+    @Column(name = "like_count") //sql 의 like 문과 충돌 발생해서 like_count 로 컬럼 생성
+    private int like;
+
+    @OneToMany
+    private List<Image> images;
+}

--- a/src/main/java/com/capstone/shop/entity/PictureType.java
+++ b/src/main/java/com/capstone/shop/entity/PictureType.java
@@ -1,0 +1,5 @@
+package com.capstone.shop.entity;
+
+public enum PictureType {
+    MERCHANTDISE
+}

--- a/src/main/java/com/capstone/shop/user/v1/controller/MerchandiseController.java
+++ b/src/main/java/com/capstone/shop/user/v1/controller/MerchandiseController.java
@@ -1,0 +1,58 @@
+package com.capstone.shop.user.v1.controller;
+
+import com.capstone.shop.user.v1.dto.MerchandisePaginationResponse;
+import com.capstone.shop.user.v1.dto.MerchandiseRegisterRequest;
+import com.capstone.shop.user.v1.dto.MerchandiseResponse;
+import com.capstone.shop.user.v1.dto.PaginationResponse;
+import com.capstone.shop.user.v1.service.MerchandiseService;
+import com.capstone.shop.entity.Merchandise;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/merchandise")
+public class MerchandiseController {
+    private final MerchandiseService merchandiseService;
+
+    @GetMapping
+    public MerchandisePaginationResponse getMerchandise(
+            @RequestParam(value = "page", defaultValue = "0", required = false) int page,
+            @RequestParam(value = "size", defaultValue = "20", required = false) int size,
+            @RequestParam(value = "sort", defaultValue = "like,desc", required = false) String sort,
+            @RequestParam(value = "search", defaultValue = "", required = false) String search) {
+
+        String[] sortParams = sort.split(",");
+        String sortField = sortParams[0];
+        Sort.Direction sortDirection = Sort.Direction.fromString(sortParams[1]);
+
+        Pageable pageable = PageRequest.of(page, size, Sort.by(sortDirection, sortField));
+
+        Page<Merchandise> merchandisePage = merchandiseService.getMerchandise(search, pageable);
+
+        List<MerchandiseResponse> merchandiseList = MerchandiseResponse.getMerchandiseResponses(merchandisePage);
+        PaginationResponse pagination = new PaginationResponse(page, size, sort, search, merchandisePage);
+
+        return new MerchandisePaginationResponse(merchandiseList, pagination);
+    }
+
+    @PostMapping
+    public ResponseEntity<String> createMerchandise(@RequestBody MerchandiseRegisterRequest request) {
+        boolean result = merchandiseService.createMerchandise(request.toEntity());
+        if (result) {
+            return ResponseEntity.ok("success to create merchandise");
+        }
+        return ResponseEntity.badRequest().body("merchandise could not be created");
+    }
+}

--- a/src/main/java/com/capstone/shop/user/v1/dto/MerchandisePaginationResponse.java
+++ b/src/main/java/com/capstone/shop/user/v1/dto/MerchandisePaginationResponse.java
@@ -1,0 +1,13 @@
+package com.capstone.shop.user.v1.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@AllArgsConstructor
+@Getter
+public class MerchandisePaginationResponse {
+    private List<MerchandiseResponse> merchandise;
+    private PaginationResponse pagination;
+}

--- a/src/main/java/com/capstone/shop/user/v1/dto/MerchandiseRegisterRequest.java
+++ b/src/main/java/com/capstone/shop/user/v1/dto/MerchandiseRegisterRequest.java
@@ -1,0 +1,25 @@
+package com.capstone.shop.user.v1.dto;
+
+import com.capstone.shop.entity.Merchandise;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@AllArgsConstructor
+@Setter
+@Getter
+public class MerchandiseRegisterRequest {
+    private String name;
+    private int price;
+    private String location;
+    private List<String> images;
+
+    public Merchandise toEntity() {
+        return Merchandise.builder()
+                .name(name)
+                .price(price)
+                .location(location)
+                .build();
+    }
+}

--- a/src/main/java/com/capstone/shop/user/v1/dto/MerchandiseResponse.java
+++ b/src/main/java/com/capstone/shop/user/v1/dto/MerchandiseResponse.java
@@ -1,0 +1,41 @@
+package com.capstone.shop.user.v1.dto;
+
+import com.capstone.shop.entity.Image;
+import com.capstone.shop.entity.Merchandise;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+@AllArgsConstructor
+@Builder
+@Getter
+public class MerchandiseResponse {
+    private Long id;
+    private String name;
+    private int price;
+    private String location;
+    private int like;
+    private List<String> images;
+
+    public MerchandiseResponse(Merchandise entity) {
+        this.id = entity.getId();
+        this.name = entity.getName();
+        this.price = entity.getPrice();
+        this.location = entity.getLocation();
+        this.like = entity.getLike();
+        this.images = entity.getImages()
+                .stream()
+                .map(Image::getPictureUrl)
+                .toList();
+    }
+
+    public static List<MerchandiseResponse> getMerchandiseResponses(Page<Merchandise> merchandisePage) {
+        return merchandisePage
+                .getContent()
+                .stream()
+                .map(MerchandiseResponse::new)
+                .toList();
+    }
+}

--- a/src/main/java/com/capstone/shop/user/v1/dto/PaginationResponse.java
+++ b/src/main/java/com/capstone/shop/user/v1/dto/PaginationResponse.java
@@ -1,0 +1,32 @@
+package com.capstone.shop.user.v1.dto;
+
+import com.capstone.shop.entity.Merchandise;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+@AllArgsConstructor
+@Builder
+@Getter
+public class PaginationResponse {
+    private int page;
+    private int totalPages;
+    private int requestSize;
+    private int responseSize;
+    private String sort;
+    private String search;
+    private boolean last;
+    private boolean first;
+
+    public PaginationResponse(int page, int size, String sort, String search, Page<Merchandise> merchandisePage) {
+        this.page = page;
+        this.totalPages = merchandisePage.getTotalPages();
+        this.requestSize = size;
+        this.responseSize = merchandisePage.getNumberOfElements();
+        this.sort = sort;
+        this.search = search;
+        this.first = merchandisePage.isFirst();
+        this.last = merchandisePage.isLast();
+    }
+}

--- a/src/main/java/com/capstone/shop/user/v1/repository/MerchandiseRepository.java
+++ b/src/main/java/com/capstone/shop/user/v1/repository/MerchandiseRepository.java
@@ -1,0 +1,12 @@
+package com.capstone.shop.user.v1.repository;
+
+import com.capstone.shop.entity.Merchandise;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MerchandiseRepository extends JpaRepository<Merchandise, Long> {
+    Page<Merchandise> findByNameContaining(String search, Pageable pageable);
+}

--- a/src/main/java/com/capstone/shop/user/v1/service/MerchandiseService.java
+++ b/src/main/java/com/capstone/shop/user/v1/service/MerchandiseService.java
@@ -1,0 +1,12 @@
+package com.capstone.shop.user.v1.service;
+
+import com.capstone.shop.entity.Merchandise;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface MerchandiseService {
+
+    Page<Merchandise> getMerchandise(String search, Pageable pageable);
+
+    boolean createMerchandise(Merchandise entity);
+}

--- a/src/main/java/com/capstone/shop/user/v1/service/MerchandiseServiceImpl.java
+++ b/src/main/java/com/capstone/shop/user/v1/service/MerchandiseServiceImpl.java
@@ -1,0 +1,25 @@
+package com.capstone.shop.user.v1.service;
+
+import com.capstone.shop.user.v1.repository.MerchandiseRepository;
+import com.capstone.shop.entity.Merchandise;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MerchandiseServiceImpl implements MerchandiseService {
+    private final MerchandiseRepository merchandiseRepository;
+
+    @Override
+    public Page<Merchandise> getMerchandise(String search, Pageable pageable) {
+        return merchandiseRepository.findByNameContaining(search, pageable);
+    }
+
+    @Override
+    public boolean createMerchandise(Merchandise entity) {
+        entity = merchandiseRepository.save(entity);
+        return entity.getId() != null;
+    }
+}


### PR DESCRIPTION
1. 내부적으로 쿼리를 날릴때 Page<> 인터페이스 사용하되, request/response dto 는 따로 만들었음. 이유1: request param 을 Page<>로 받으면 기본값을 설정하기 힘듬.
이유2: response body 에 불필요한 값을 제거하기 힘듬.
2. POST /api/v1/merchandise api 의 응답을 ResponseEntity 를 이용해서 반환함. 다른 개발자와의 일관성을 지키기 위해. 추후 수정할 예정.