### PR TITLE
fix: docker 내에서 db 와 연결할수 없는 현상 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,4 +29,4 @@ COPY --from=builder-jre /jre $JAVA_HOME
 
 COPY ./build/libs/*.jar ./shop-server.jar
 
-ENTRYPOINT ["java", "-Duser.timezone=Asia/Seoul", "-jar", "shop-server.jar"]
+ENTRYPOINT ["java", "-Duser.timezone=Asia/Seoul", "-Dspring.profiles.active=docker", "-jar", "shop-server.jar"]


### PR DESCRIPTION
도커 내에서는 호스트의 프로세스와 통신할때 localhost 가 아니라, host.docker.internal 와 통신해야 한다.