### PR TITLE
fix : ci/cd 실행시 docker/build-push-actions@v6 에서 불필요하게 체크아웃 하는 문제 수정

### DIFF
--- a/.github/workflows/cd-aws.yml
+++ b/.github/workflows/cd-aws.yml
@@ -49,15 +49,17 @@ jobs:
       - name: Admin Image Build and push
         uses: docker/build-push-action@v6
         with:
+          context: 'docker/'
           push: true
-          file: 'docker/Dockerfile-admin'
+          file: 'Dockerfile-admin'
           tags: ${{ secrets.DOCKER_REGISTRY }}/admin-image:latest
 
       - name: User Image Build and push
         uses: docker/build-push-action@v6
         with:
+          context: 'docker/'
           push: true
-          file: 'docker/Dockerfile-user'
+          file: 'Dockerfile-user'
           tags: ${{ secrets.DOCKER_REGISTRY }}/user-image:latest
 
         # 서버에 ssh 로 접속해서


### PR DESCRIPTION
https://github.com/docker/build-push-action/issues/1089 이 이슈와 비슷함