### PR TITLE
fix : ci/cd 실행시 최신 이미지를 실행하지 않는 문제 수정

### DIFF
--- a/.github/workflows/cd-aws.yml
+++ b/.github/workflows/cd-aws.yml
@@ -74,5 +74,5 @@ jobs:
           key: ${{ secrets.EC2_SSH_KEY }}
           script: |
             cd backend
-            docker-compose down
-            docker-compose up -d
+            docker compose down
+            docker compose up -d

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,11 +1,11 @@
 services:
   user:
-    image: "${registry}/user-image"
+    image: "${registry}/user-image:latest"
     ports:
       - 8081:8081
     container_name: user-container
   admin:
-    image: "${registry}/admin-image"
+    image: "${registry}/admin-image:latest"
     ports:
       - 8080:8080
     container_name: admin-container


### PR DESCRIPTION
fix : ci/cd 실행시 docker-compose 명령어 대신 docker compose 명령어를 쓰게 수정(전자를 사용하면 서버에 docker-compose 를 따로 설치해야 함.)