### PR TITLE
fix : ci/cd 실행시 가끔씩 이미지 push 가 너무 느리거나 멈추는 경우가 있음. 타임아웃을 둬서, push 가 너…

### DIFF
--- a/.github/workflows/cd-aws.yml
+++ b/.github/workflows/cd-aws.yml
@@ -6,7 +6,7 @@ on: # 아래의 조건을 만족할때 실행
       - closed
 
 jobs:
-  build:
+  continuous-deployment:
     # https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#running-your-pull_request_target-workflow-when-a-pull-request-merges
     # pull_request 가 승인된 상황에만 아래를 실행하기 위해, github.event.pull_request.merged 가 true 인지 체크.
     if: (github.event.pull_request.merged)
@@ -15,6 +15,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+
+    timeout-minutes: 5
 
     steps:
       - name: Checkout server
@@ -35,6 +37,7 @@ jobs:
 
       - name: Build with Gradle
         run: ./gradlew build
+        timeout-minutes: 2
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -48,6 +51,7 @@ jobs:
 
       - name: Admin Image Build and push
         uses: docker/build-push-action@v6
+        timeout-minutes: 3
         with:
           context: .
           push: true
@@ -56,6 +60,7 @@ jobs:
 
       - name: User Image Build and push
         uses: docker/build-push-action@v6
+        timeout-minutes: 3
         with:
           context: .
           push: true


### PR DESCRIPTION
…무 느릴때는 취소하고자 함.

cd 작업 전체 타임아웃 : 5분으로 설정
gradle build 타임아웃 : 2분으로 설정
이미지 하나 push 타임아웃 : 3분으로 설정